### PR TITLE
Fixes VSCode Terminal Rendering

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -13,25 +13,25 @@
 # -- general -------------------------------------------------------------------
 
 set -g default-terminal "screen-256color"
-#set inactive/active window styles
-#set -g window-style 'fg=colour46, bg=colour16'
-#set -g window-active-style 'fg=colour46, bg=colour16'
+# set inactive/active window styles
+set -g window-style 'fg=colour46, bg=colour16'
+set -g window-active-style 'fg=colour46, bg=colour16'
 
-#set -g pane-border-style 'fg=colour46, bg=colour16'
-#set -g pane-active-border-style 'fg=colour46, bg=colour16'
+set -g pane-border-style 'fg=colour46, bg=colour16'
+set -g pane-active-border-style 'fg=colour46, bg=colour16'
 
 setw -g xterm-keys on
-set -s escape-time 10                     # faster command sequences
+set -s escape-time 200                     # faster command sequences
 set -sg repeat-time 600                   # increase repeat timeout
 set -s focus-events on
 
-set -g prefix2 C-a                        # GNU-Screen compatible prefix
+#set -g prefix2 C-a                        # GNU-Screen compatible prefix
 bind C-a send-prefix -2
 
-#set -q -g status-utf8 on                  # expect UTF-8 (tmux < 2.2) XXX BUG on VSCODE
+#set -q -g status-utf8 on                  # expect UTF-8 (tmux < 2.2)
 setw -q -g utf8 on
 
-set -g history-limit 5000                 # boost history
+#set -g history-limit 5000                 # boost history
 
 # edit configuration
 bind e new-window -n "#{TMUX_CONF_LOCAL}" sh -c '${EDITOR:-vim} "$TMUX_CONF_LOCAL" && "$TMUX_PROGRAM" ${TMUX_SOCKET:+-S "$TMUX_SOCKET"} source "$TMUX_CONF" \; display "$TMUX_CONF_LOCAL sourced"'

--- a/tmux.conf
+++ b/tmux.conf
@@ -14,11 +14,11 @@
 
 set -g default-terminal "screen-256color"
 #set inactive/active window styles
-set -g window-style 'fg=colour46, bg=colour16'
-set -g window-active-style 'fg=colour46, bg=colour16'
+#set -g window-style 'fg=colour46, bg=colour16'
+#set -g window-active-style 'fg=colour46, bg=colour16'
 
-set -g pane-border-style 'fg=colour46, bg=colour16'
-set -g pane-active-border-style 'fg=colour46, bg=colour16'
+#set -g pane-border-style 'fg=colour46, bg=colour16'
+#set -g pane-active-border-style 'fg=colour46, bg=colour16'
 
 setw -g xterm-keys on
 set -s escape-time 10                     # faster command sequences


### PR DESCRIPTION
![with-out-tmux](https://github.com/tijko/dotfiles/assets/1518884/5841a979-8c7b-4736-888f-fd25cba4f957)

![with-tmux](https://github.com/tijko/dotfiles/assets/1518884/de3d756a-5310-4247-889f-2a00282d6972)

When starting up VSCode the Terminal sessions will dump errant escape sequences from the tmux server.